### PR TITLE
fix: update deps and docs for browser tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,16 @@ Todo se carga vía CDN: no se necesitan instalaciones locales.
 
 ## Desarrollo
 
-Simplemente abre `web/index.html` en tu navegador para trabajar en local. No se necesita servidor.
+Para desarrollar en local se necesita un servidor web sencillo. Desde la
+carpeta `web` puedes ejecutar, por ejemplo:
+
+```bash
+cd web
+python -m http.server 8000
+```
+
+Luego visita <http://localhost:8000/> en tu navegador. Abrir el archivo
+directamente con `file://` produce errores de CORS con los módulos ES.
 
 ## Licencia
 

--- a/web/index.html
+++ b/web/index.html
@@ -90,8 +90,11 @@
 </footer>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/mocha/mocha.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/chai/chai.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/fast-check@3.13.1/lib/fast-check.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chai@4.3.7/chai.js"></script>
+<script type="module">
+  import * as fc from 'https://cdn.jsdelivr.net/npm/fast-check@3.13.1/lib/esm/fast-check.js';
+  window.fc = fc;
+</script>
 <script src="https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js"></script>
 <script>mocha.setup('bdd'); const expect = chai.expect;</script>
 <script type="module" src="js/controller.js"></script>


### PR DESCRIPTION
## Summary
- load Chai 4.3.7 and use fast-check's ESM build to avoid MIME issues
- document running `web` with a local server to prevent CORS errors

## Testing
- `node --input-type=module <<'NODE'
import { expect } from 'chai';
import * as fc from 'fast-check';
import { quicksort } from './web/js/quicksort.js';
expect(quicksort([3,1,2]).array).to.deep.equal([1,2,3]);
expect(quicksort([]).array).to.deep.equal([]);
await fc.assert(fc.property(fc.array(fc.integer()), a => {
  const res = quicksort(a.slice());
  const sorted = a.slice().sort((x,y)=>x-y);
  return JSON.stringify(res.array) === JSON.stringify(sorted);
}));
console.log('tests passed');
NODE`

------
https://chatgpt.com/codex/tasks/task_e_689d48a326588325bf32e62fb403bb3a